### PR TITLE
SPM & .pbxproj fixes

### DIFF
--- a/ImpressionKit.xcodeproj/project.pbxproj
+++ b/ImpressionKit.xcodeproj/project.pbxproj
@@ -11,9 +11,9 @@
 		5C1ED03A26637C7900C68451 /* ImpressionKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C1ED03826637C7900C68451 /* ImpressionKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5C1ED06B26637D5A00C68451 /* UIViewFunctionExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C1ED06A26637D5A00C68451 /* UIViewFunctionExtension.swift */; };
 		5C1ED0812663DD7B00C68451 /* UIViewPropertyExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C1ED0802663DD7B00C68451 /* UIViewPropertyExtension.swift */; };
-		5C87C66A266531AD006E824E /* Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C87C669266531AD006E824E /* Debug.swift */; };
 		5CDD55322667587B00FBF47E /* ImpressionGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CDD55312667587B00FBF47E /* ImpressionGroup.swift */; };
 		62F7F59326A9708D003DF049 /* ImpressionKit+ViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62F7F59226A9708D003DF049 /* ImpressionKit+ViewModifier.swift */; };
+		FC73BCDA27C99E92008B9765 /* ImpressionKitDebug.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC73BCD927C99E92008B9765 /* ImpressionKitDebug.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -25,9 +25,9 @@
 		5C1ED03926637C7900C68451 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		5C1ED06A26637D5A00C68451 /* UIViewFunctionExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewFunctionExtension.swift; sourceTree = "<group>"; };
 		5C1ED0802663DD7B00C68451 /* UIViewPropertyExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewPropertyExtension.swift; sourceTree = "<group>"; };
-		5C87C669266531AD006E824E /* Debug.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Debug.swift; sourceTree = "<group>"; };
 		5CDD55312667587B00FBF47E /* ImpressionGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImpressionGroup.swift; sourceTree = "<group>"; };
 		62F7F59226A9708D003DF049 /* ImpressionKit+ViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ImpressionKit+ViewModifier.swift"; sourceTree = "<group>"; };
+		FC73BCD927C99E92008B9765 /* ImpressionKitDebug.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImpressionKitDebug.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -63,11 +63,11 @@
 		5C1ED03726637C7900C68451 /* ImpressionKit */ = {
 			isa = PBXGroup;
 			children = (
+				FC73BCD927C99E92008B9765 /* ImpressionKitDebug.swift */,
 				5C1ED03826637C7900C68451 /* ImpressionKit.h */,
 				5C1ED0802663DD7B00C68451 /* UIViewPropertyExtension.swift */,
 				5C1ED06A26637D5A00C68451 /* UIViewFunctionExtension.swift */,
 				5CDD55312667587B00FBF47E /* ImpressionGroup.swift */,
-				5C87C669266531AD006E824E /* Debug.swift */,
 				5C1ED03926637C7900C68451 /* Info.plist */,
 				62F7F59226A9708D003DF049 /* ImpressionKit+ViewModifier.swift */,
 			);
@@ -196,8 +196,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5C87C66A266531AD006E824E /* Debug.swift in Sources */,
 				5C1ED06B26637D5A00C68451 /* UIViewFunctionExtension.swift in Sources */,
+				FC73BCDA27C99E92008B9765 /* ImpressionKitDebug.swift in Sources */,
 				62F7F59326A9708D003DF049 /* ImpressionKit+ViewModifier.swift in Sources */,
 				5CDD55322667587B00FBF47E /* ImpressionGroup.swift in Sources */,
 				5C1ED0812663DD7B00C68451 /* UIViewPropertyExtension.swift in Sources */,

--- a/ImpressionKit/ImpressionKitDebug.swift
+++ b/ImpressionKit/ImpressionKitDebug.swift
@@ -7,7 +7,11 @@
 
 #if DEBUG
 import Foundation
+#if SWIFT_PACKAGE
+import SwiftHook
+#else
 import EasySwiftHook
+#endif
 
 public class ImpressionKitDebug {
     

--- a/ImpressionKit/ImpressionKitDebug.swift
+++ b/ImpressionKit/ImpressionKitDebug.swift
@@ -6,7 +6,7 @@
 //
 
 #if DEBUG
-import Foundation
+import UIKit
 #if SWIFT_PACKAGE
 import SwiftHook
 #else


### PR DESCRIPTION
When attempting to use `ImpressionKit` via SPM, `ImpressionKitDebug.swift` kept throwing `No such module: EasySwiftHook`, I presume this is due to the name difference between SPM and pods, this PR should hopefully fix this, as well as unable to find `UIResponder`. There was an also a `.pbxproj` issue with the recent rename of `Debug.swift` -> `ImpressionKitDebug.swift`. @623637646 would be great if this could be reviewed, merged, and released into an updated version soon! 😄 