### PR TITLE
Fix .detectImpression view modifier blocking touches

### DIFF
--- a/ImpressionKit/ImpressionKit+ViewModifier.swift
+++ b/ImpressionKit/ImpressionKit+ViewModifier.swift
@@ -58,7 +58,8 @@ private struct ImpressionTrackableModifier: ViewModifier {
                                     areaRatioThreshold: areaRatioThreshold,
                                     redetectOptions: redetectOptions,
                                     onCreated: onCreated,
-                                    onChanged: onChanged))
+                                    onChanged: onChanged)
+                        .allowsHitTesting(false))
     }
 }
 


### PR DESCRIPTION
## Description
Using a SwiftUI view modifier (i.e. `.detectImpression(group: viewModel.group, index: index)`) causes user interaction to be blocked **when** the `.detectImpression` is placed on the same level or higher than a gesture recogniser - this is an issue for complex views with multiple touch targets but the view as a whole should be tracked. This change adds `.allowsHitTesting(false)` to the overlay added via the view modifier, thus allowing touches to pass through it.

## Testing
With the below `.onTapGesture { ... }` view modifier is inserted into the chain above the `.detectImpression` line in `SwiftUIListDemoView.swift`, then the tap will be blocked by the `.detectImpression(...)`s `UIView` currently, whereas with the change it'll be registered.

```swift
.onTapGesture {
    print("SwiftUIListDemoView.CellView \(index) tapped")
}
```

Let me know if there are any issues, otherwise it'd be great to get this merged and tagged @623637646 😄 
