### PR TITLE
didBecomeActive notification support

### DIFF
--- a/ImpressionKit/ImpressionGroup.swift
+++ b/ImpressionKit/ImpressionGroup.swift
@@ -193,5 +193,14 @@ public class ImpressionGroup<IndexType: Hashable> {
             }
             self.notificationTokens.append(token)
         }
+        if redetectOptions.contains(.didBecomeActive) {
+            let token = NotificationCenter.default.addObserver(forName: UIApplication.didBecomeActiveNotification, object: nil, queue: nil) { [weak self] _ in
+                guard let self = self else {
+                    return
+                }
+                self.resetGroupStateAndRedetect(.didBecomeActive)
+            }
+            self.notificationTokens.append(token)
+        }
     }
 }

--- a/ImpressionKit/UIViewFunctionExtension.swift
+++ b/ImpressionKit/UIViewFunctionExtension.swift
@@ -173,6 +173,9 @@ extension UIView {
         if self.isRedetectionOn(.willResignActive) {
             names.append(UIApplication.willResignActiveNotification)
         }
+        if self.isRedetectionOn(.didBecomeActive) {
+            names.append(UIApplication.didBecomeActiveNotification)
+        }
         guard names.count > 0 else {
             return
         }
@@ -186,6 +189,8 @@ extension UIView {
                     self.impressionState = .didEnterBackground
                 } else if notification.name == UIApplication.willResignActiveNotification {
                     self.impressionState = .willResignActive
+                } else if notification.name == UIApplication.didBecomeActiveNotification {
+                    self.impressionState = .didBecomeActive
                 } else {
                     assert(false)
                     return

--- a/ImpressionKit/UIViewPropertyExtension.swift
+++ b/ImpressionKit/UIViewPropertyExtension.swift
@@ -37,6 +37,7 @@ extension UIView {
         case viewControllerDidDisappear
         case didEnterBackground
         case willResignActive
+        case didBecomeActive
         
         public var isImpressed: Bool {
             if case .impressed = self {

--- a/ImpressionKit/UIViewPropertyExtension.swift
+++ b/ImpressionKit/UIViewPropertyExtension.swift
@@ -143,6 +143,9 @@ extension UIView {
         
         // Retrigger the impression event when the App will resign active.
         public static let willResignActive = Redetect(rawValue: 1 << 3)
+        
+        // Retrigger the impression event when the App becomes active.
+        public static let didBecomeActive = Redetect(rawValue: 1 << 4)
     }
     
     // Retrigger the impression. Apply to all views.


### PR DESCRIPTION
#### Description
---
My use case needs the ability to re-impress when returning from being backgrounded, so this PR adds that notification hook in. It seems to work well in the UIKit group pathway that's I'm using.